### PR TITLE
SPA遷移検知の対象URLを拡張

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -11,30 +11,18 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": [
-    "storage"
-  ],
-  "host_permissions": [
-    "https://video.dmm.co.jp/av/*"
-  ],
+  "permissions": ["storage"],
+  "host_permissions": ["https://video.dmm.co.jp/*"],
   "content_scripts": [
     {
-      "matches": [
-        "https://video.dmm.co.jp/av/*"
-      ],
-      "js": [
-        "build/historyWatcher.js"
-      ],
+      "matches": ["https://video.dmm.co.jp/*"],
+      "js": ["build/historyWatcher.js"],
       "run_at": "document_start",
       "world": "MAIN"
     },
     {
-      "matches": [
-        "https://video.dmm.co.jp/av/*"
-      ],
-      "js": [
-        "build/historySaver.js"
-      ],
+      "matches": ["https://video.dmm.co.jp/*"],
+      "js": ["build/historySaver.js"],
       "run_at": "document_start"
     }
   ]

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FANZA History",
   "description": "FANZAの商品閲覧履歴を保存・表示する拡張機能",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "manifest_version": 3,
   "icons": {
     "16": "icons/icon16.png",
@@ -11,18 +11,30 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage"],
-  "host_permissions": ["https://video.dmm.co.jp/*"],
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://video.dmm.co.jp/*"
+  ],
   "content_scripts": [
     {
-      "matches": ["https://video.dmm.co.jp/*"],
-      "js": ["build/historyWatcher.js"],
+      "matches": [
+        "https://video.dmm.co.jp/*"
+      ],
+      "js": [
+        "build/historyWatcher.js"
+      ],
       "run_at": "document_start",
       "world": "MAIN"
     },
     {
-      "matches": ["https://video.dmm.co.jp/*"],
-      "js": ["build/historySaver.js"],
+      "matches": [
+        "https://video.dmm.co.jp/*"
+      ],
+      "js": [
+        "build/historySaver.js"
+      ],
       "run_at": "document_start"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dmm-history",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packageManager": "pnpm@10.21.0",
   "engines": {
     "node": "24.7.0"


### PR DESCRIPTION
## 概要

SPA遷移時の履歴保存処理が動くように、content scripts の対象URLを拡張しました。

## 変更内容

- `host_permissions` を `https://video.dmm.co.jp/*` に変更
- `historyWatcher.js` の `matches` を `https://video.dmm.co.jp/*` に変更
- `historySaver.js` の `matches` を `https://video.dmm.co.jp/*` に変更

## 確認内容

- `pnpm build`
- Chrome 拡張として読み込み、SPA遷移後に履歴保存されることを確認