### PR TITLE
feat: 商品情報の取得拡張とサンプル動画再生機能を追加

### DIFF
--- a/ITEM_PAGE_METRICS_STATUS.md
+++ b/ITEM_PAGE_METRICS_STATUS.md
@@ -1,0 +1,77 @@
+# ITEM_PAGE_METRICS_STATUS.md
+
+## 目的
+
+このファイルは、商品ページから追加の指標を取得する対応の状況を残すためのものです。
+対象は、サンプル動画の有無、サンプル動画の再生回数、お気に入り登録数です。
+
+## 現在の全体状況
+
+- 状態: 実装中
+- 対象ページ: URL履歴保存対象の商品ページ
+- 現在の大きな課題: 実サイトでiframe内の再生回数を正しく受け取れるか確認する
+
+## 進行ルール
+
+- DOM取得処理は `chrome/src/utils/itemPage.ts` にまとめる
+- 履歴保存処理は `chrome/src/chrome/historySaver.ts` にまとめる
+- 実サイトのDOM変更に備えて、取得処理にはテストを追加する
+- 確認できていないことは、このファイルに残す
+
+## 作業一覧
+
+- フェーズ 1: **履歴データの拡張**
+  - [x] `History` 型にサンプル動画関連の項目を追加する
+    - [x] `hasSampleVideo` を追加する
+    - [x] `sampleVideoPlayCount` を追加する
+  - [x] `History` 型にお気に入り登録数を追加する
+    - [x] `favoriteCount` を追加する
+  - [x] モック履歴と既存テストの履歴データを新しい型に合わせる
+
+- フェーズ 2: **商品ページのDOM取得処理**
+  - [x] サンプル動画プレイヤーのiframe有無を取得する
+  - [x] サンプル動画の再生回数を取得する
+  - [x] お気に入り登録数を取得する
+  - [x] 件数文字列を数値に変換する補助関数を追加する
+  - [x] 追加した取得処理のテストを追加する
+
+- フェーズ 3: **iframe内の再生回数取得**
+  - [x] iframe用のcontent scriptを追加する
+  - [x] iframe側から親ページへ再生回数を送る
+  - [x] 親ページ側で受け取った再生回数を履歴保存に使う
+  - [x] `manifest.json` にiframe用content scriptを追加する
+  - [x] `webpack.config.js` にiframe用entryを追加する
+
+- フェーズ 4: **確認**
+  - [x] `git diff --check` で空白エラーがないことを確認する
+  - [ ] `pnpm format:check` を実行する
+  - [ ] `pnpm check-types` を実行する
+  - [ ] `pnpm test` を実行する
+  - [ ] `pnpm build` を実行する
+  - [ ] 実サイトの商品ページで手動確認する
+
+## 手動確認したいこと
+
+- サンプル動画がある商品で `hasSampleVideo` が `true` になる
+- サンプル動画がない商品で `hasSampleVideo` が `false` になる
+- iframe内の再生回数が `sampleVideoPlayCount` に保存される
+- お気に入り登録数が `favoriteCount` に保存される
+- 既存の履歴保存、一覧表示、検索、削除が動く
+
+## 課題・注意点
+
+- サンプル動画の再生回数はiframe内にあるため、iframe用content scriptから親ページへ送っている
+- この環境では `node`、`pnpm`、`mise` がPATHに無く、型チェックやテストをまだ実行できていない
+- 実サイトのDOM構造が変わると、取得処理を見直す必要がある
+
+## メモ
+
+- 推奨ブランチ名: `feat/item-page-metrics`
+- 追加した主なファイル:
+  - `chrome/src/chrome/sampleVideoReader.ts`
+  - `chrome/src/models/sampleVideo.ts`
+- 変更した主なファイル:
+  - `chrome/src/chrome/historySaver.ts`
+  - `chrome/src/utils/itemPage.ts`
+  - `chrome/manifest.json`
+  - `chrome/webpack.config.js`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ FANZAの商品閲覧履歴を保存・表示する拡張機能。
 
 ## インストール方法
 
-1. FANZA Historyの実行ファイルである[chrome.zip](https://github.com/hira777/dmm-history/releases/download/v1.0.6/chrome.zip)をダウンロード。
+1. FANZA Historyの実行ファイルである[chrome.zip](https://github.com/hira777/dmm-history/releases/latest/download/chrome.zip)をダウンロード。
 2. ダウンロードした`chrome.zip`を任意の場所に解凍する。
 3. 以下のように「パッケージ化されていない拡張機能を読み込む」を選択し、解凍したディレクトリを選択すれば拡張が読み込まれる。
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -11,40 +11,26 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage"],
   "host_permissions": [
     "https://video.dmm.co.jp/*",
     "https://www.dmm.co.jp/service/digitalapi/*"
   ],
   "content_scripts": [
     {
-      "matches": [
-        "https://video.dmm.co.jp/*"
-      ],
-      "js": [
-        "build/historyWatcher.js"
-      ],
+      "matches": ["https://video.dmm.co.jp/*"],
+      "js": ["build/historyWatcher.js"],
       "run_at": "document_start",
       "world": "MAIN"
     },
     {
-      "matches": [
-        "https://video.dmm.co.jp/*"
-      ],
-      "js": [
-        "build/historySaver.js"
-      ],
+      "matches": ["https://video.dmm.co.jp/*"],
+      "js": ["build/historySaver.js"],
       "run_at": "document_start"
     },
     {
-      "matches": [
-        "https://www.dmm.co.jp/service/digitalapi/*"
-      ],
-      "js": [
-        "build/sampleVideoReader.js"
-      ],
+      "matches": ["https://www.dmm.co.jp/service/digitalapi/*"],
+      "js": ["build/sampleVideoReader.js"],
       "run_at": "document_start",
       "all_frames": true
     }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -15,7 +15,8 @@
     "storage"
   ],
   "host_permissions": [
-    "https://video.dmm.co.jp/*"
+    "https://video.dmm.co.jp/*",
+    "https://www.dmm.co.jp/service/digitalapi/*"
   ],
   "content_scripts": [
     {
@@ -36,6 +37,16 @@
         "build/historySaver.js"
       ],
       "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "https://www.dmm.co.jp/service/digitalapi/*"
+      ],
+      "js": [
+        "build/sampleVideoReader.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
     }
   ]
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FANZA History",
   "description": "FANZAの商品閲覧履歴を保存・表示する拡張機能",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "manifest_version": 3,
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome/src/chrome/historySaver.ts
+++ b/chrome/src/chrome/historySaver.ts
@@ -1,10 +1,15 @@
 import { MAX_HISTORIES, URL_CHANGE_EVENT } from '@/enums';
 import { keys, ChromeStorageSchema } from '@/models/chromeStorageSchema';
 import { History } from '@/models/history';
+import {
+  SAMPLE_VIDEO_INFO_MESSAGE,
+  SampleVideoInfoMessage
+} from '@/models/sampleVideo';
 import history from '@/utils/history';
 import chromeStorage from '@/utils/chromeStorage';
 import {
   getAffiliateUrl,
+  getFavoriteCount,
   getImageUrl,
   getItemId,
   getLabel,
@@ -12,6 +17,7 @@ import {
   getPrices,
   getSaleLimitTime,
   getSalePrices,
+  hasSampleVideo,
   getTitle
 } from '@/utils/itemPage';
 import {
@@ -20,8 +26,10 @@ import {
 } from '@/utils/itemPageWaiter';
 
 const CONTENT_PATH = '/av/content/';
+const SAMPLE_VIDEO_INFO_WAIT_MS = 3000;
 
 let currentUrl = location.href;
+const sampleVideoInfoByItemId = new Map<string, number | null>();
 
 /**
  * 現在のURLが履歴保存対象の商品ページか判定する。
@@ -30,6 +38,71 @@ function isContentPage(url: string): boolean {
   const parsedUrl = new URL(url);
   return parsedUrl.pathname === CONTENT_PATH && getItemId(url) !== '';
 }
+
+/**
+ * サンプル動画情報のメッセージか判定する。
+ */
+function isSampleVideoInfoMessage(
+  message: unknown
+): message is SampleVideoInfoMessage {
+  const candidate = message as Partial<SampleVideoInfoMessage>;
+
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    candidate.type === SAMPLE_VIDEO_INFO_MESSAGE &&
+    typeof candidate.itemId === 'string' &&
+    (typeof candidate.playCount === 'number' || candidate.playCount === null)
+  );
+}
+
+/**
+ * iframeから送られるサンプル動画の再生回数を待つ。
+ */
+function waitForSampleVideoInfo(itemId: string): Promise<number | null> {
+  if (sampleVideoInfoByItemId.has(itemId)) {
+    return Promise.resolve(sampleVideoInfoByItemId.get(itemId) ?? null);
+  }
+
+  return new Promise((resolve) => {
+    let timeoutId = 0;
+
+    const listener = (event: MessageEvent): void => {
+      if (
+        event.origin !== 'https://www.dmm.co.jp' ||
+        !isSampleVideoInfoMessage(event.data) ||
+        event.data.itemId !== itemId
+      ) {
+        return;
+      }
+
+      window.clearTimeout(timeoutId);
+      window.removeEventListener('message', listener);
+      resolve(event.data.playCount);
+    };
+
+    timeoutId = window.setTimeout(() => {
+      window.removeEventListener('message', listener);
+      resolve(null);
+    }, SAMPLE_VIDEO_INFO_WAIT_MS);
+
+    window.addEventListener('message', listener);
+  });
+}
+
+/**
+ * iframeから送られるサンプル動画情報を保持する。
+ */
+window.addEventListener('message', (event: MessageEvent) => {
+  if (
+    event.origin !== 'https://www.dmm.co.jp' ||
+    !isSampleVideoInfoMessage(event.data)
+  ) {
+    return;
+  }
+
+  sampleVideoInfoByItemId.set(event.data.itemId, event.data.playCount);
+});
 
 /**
  * 商品ページの情報を取得して閲覧履歴へ保存する。
@@ -41,6 +114,10 @@ async function saveNewHistory(previousTitle: string = ''): Promise<void> {
 
   const itemId = getItemId(location.href);
   const salePrices = getSalePrices();
+  const sampleVideoExists = hasSampleVideo();
+  const sampleVideoPlayCount = sampleVideoExists
+    ? await waitForSampleVideoInfo(itemId)
+    : null;
   const saleLimitTime = salePrices
     ? await waitForSaleLimitTime().then((ready) => {
         return ready ? getSaleLimitTime() : null;
@@ -55,7 +132,10 @@ async function saveNewHistory(previousTitle: string = ''): Promise<void> {
     label: getLabel(),
     prices: getPrices(),
     salePrices,
-    saleLimitTime
+    saleLimitTime,
+    hasSampleVideo: sampleVideoExists,
+    sampleVideoPlayCount,
+    favoriteCount: getFavoriteCount()
   };
   const obj = await chromeStorage.get({ keys: keys.dmmHistory });
   const histories = history

--- a/chrome/src/chrome/historySaver.ts
+++ b/chrome/src/chrome/historySaver.ts
@@ -107,12 +107,12 @@ window.addEventListener('message', (event: MessageEvent) => {
 /**
  * 商品ページの情報を取得して閲覧履歴へ保存する。
  */
-async function saveNewHistory(previousTitle: string = ''): Promise<void> {
+async function saveNewHistory(): Promise<void> {
   if (!isContentPage(location.href)) return;
-  const ready = await waitForItemPageData({ previousTitle });
+  const itemId = getItemId(location.href);
+  const ready = await waitForItemPageData({ expectedItemId: itemId });
   if (!ready) return;
 
-  const itemId = getItemId(location.href);
   const salePrices = getSalePrices();
   const sampleVideoExists = hasSampleVideo();
   const sampleVideoPlayCount = sampleVideoExists
@@ -153,13 +153,11 @@ async function saveNewHistory(previousTitle: string = ''): Promise<void> {
 function checkUrlChange(): void {
   if (location.href === currentUrl) return;
 
-  const previousUrl = currentUrl;
   currentUrl = location.href;
 
   if (!isContentPage(location.href)) return;
 
-  const previousTitle = isContentPage(previousUrl) ? getTitle() : '';
-  saveNewHistory(previousTitle);
+  saveNewHistory();
 }
 
 /**

--- a/chrome/src/chrome/historySaver.ts
+++ b/chrome/src/chrome/historySaver.ts
@@ -17,6 +17,7 @@ import {
   getPrices,
   getSaleLimitTime,
   getSalePrices,
+  getSampleVideoUrl,
   hasSampleVideo,
   getTitle
 } from '@/utils/itemPage';
@@ -134,6 +135,7 @@ async function saveNewHistory(): Promise<void> {
     salePrices,
     saleLimitTime,
     hasSampleVideo: sampleVideoExists,
+    sampleVideoUrl: sampleVideoExists ? getSampleVideoUrl(itemId) : null,
     sampleVideoPlayCount,
     favoriteCount: getFavoriteCount()
   };

--- a/chrome/src/chrome/sampleVideoReader.ts
+++ b/chrome/src/chrome/sampleVideoReader.ts
@@ -6,10 +6,16 @@ import { getSampleVideoPlayCount } from '@/utils/itemPage';
 
 const WAIT_TIMEOUT_MS = 5000;
 
+/**
+ * サンプル動画iframeのURLから商品IDを取得する。
+ */
 const getSampleVideoItemId = (url: string): string => {
   return new URL(url).pathname.match(/\/cid=([^/]+)/)?.[1] || '';
 };
 
+/**
+ * サンプル動画の再生回数を親の商品ページへ送る。
+ */
 const sendSampleVideoInfo = (): void => {
   const itemId = getSampleVideoItemId(location.href);
   if (itemId === '') return;
@@ -23,6 +29,9 @@ const sendSampleVideoInfo = (): void => {
   window.parent.postMessage(message, 'https://video.dmm.co.jp');
 };
 
+/**
+ * サンプル動画の再生回数が読み取れるまで待つ。
+ */
 const waitForSampleVideoInfo = (): void => {
   if (getSampleVideoPlayCount() !== null) {
     sendSampleVideoInfo();

--- a/chrome/src/chrome/sampleVideoReader.ts
+++ b/chrome/src/chrome/sampleVideoReader.ts
@@ -1,0 +1,64 @@
+import {
+  SAMPLE_VIDEO_INFO_MESSAGE,
+  SampleVideoInfoMessage
+} from '@/models/sampleVideo';
+import { getSampleVideoPlayCount } from '@/utils/itemPage';
+
+const WAIT_TIMEOUT_MS = 5000;
+
+const getSampleVideoItemId = (url: string): string => {
+  return new URL(url).pathname.match(/\/cid=([^/]+)/)?.[1] || '';
+};
+
+const sendSampleVideoInfo = (): void => {
+  const itemId = getSampleVideoItemId(location.href);
+  if (itemId === '') return;
+
+  const message: SampleVideoInfoMessage = {
+    type: SAMPLE_VIDEO_INFO_MESSAGE,
+    itemId,
+    playCount: getSampleVideoPlayCount()
+  };
+
+  window.parent.postMessage(message, 'https://video.dmm.co.jp');
+};
+
+const waitForSampleVideoInfo = (): void => {
+  if (getSampleVideoPlayCount() !== null) {
+    sendSampleVideoInfo();
+    return;
+  }
+
+  let settled = false;
+  const observer = new MutationObserver(() => {
+    if (getSampleVideoPlayCount() !== null) {
+      finish();
+    }
+  });
+  let timeoutId = 0;
+
+  const finish = (): void => {
+    if (settled) return;
+
+    settled = true;
+    window.clearTimeout(timeoutId);
+    observer.disconnect();
+    sendSampleVideoInfo();
+  };
+
+  timeoutId = window.setTimeout(finish, WAIT_TIMEOUT_MS);
+
+  const root = document.documentElement;
+  if (!root) {
+    finish();
+    return;
+  }
+
+  observer.observe(root, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+};
+
+waitForSampleVideoInfo();

--- a/chrome/src/models/history.ts
+++ b/chrome/src/models/history.ts
@@ -10,6 +10,7 @@ export type History = Readonly<{
   salePrices: Prices | null;
   saleLimitTime: string | null;
   hasSampleVideo: boolean;
+  sampleVideoUrl: string | null;
   sampleVideoPlayCount: number | null;
   favoriteCount: number | null;
 }>;

--- a/chrome/src/models/history.ts
+++ b/chrome/src/models/history.ts
@@ -9,5 +9,8 @@ export type History = Readonly<{
   prices: Prices;
   salePrices: Prices | null;
   saleLimitTime: string | null;
+  hasSampleVideo: boolean;
+  sampleVideoPlayCount: number | null;
+  favoriteCount: number | null;
 }>;
 export type Histories = History[] | [];

--- a/chrome/src/models/sampleVideo.ts
+++ b/chrome/src/models/sampleVideo.ts
@@ -1,0 +1,7 @@
+export const SAMPLE_VIDEO_INFO_MESSAGE = 'dmm-history:sample-video-info';
+
+export type SampleVideoInfoMessage = Readonly<{
+  type: typeof SAMPLE_VIDEO_INFO_MESSAGE;
+  itemId: string;
+  playCount: number | null;
+}>;

--- a/chrome/src/react/App.scss
+++ b/chrome/src/react/App.scss
@@ -6,3 +6,4 @@
 @use './components/HistoriesSummary';
 @use './components/HistoryCards';
 @use './components/HistoryCard';
+@use './components/SampleVideoModal';

--- a/chrome/src/react/App.tsx
+++ b/chrome/src/react/App.tsx
@@ -1,14 +1,16 @@
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 
 import Header from './components/Header';
 import HistoriesSummary from './components/HistoriesSummary';
 import HistoryCards from './components/HistoryCards';
+import SampleVideoModal from './components/SampleVideoModal';
 import { useHistories } from './hooks/useHistories';
 import './App.scss';
 
 export default function App(): ReactElement {
   const { allItems, items, searchInput, setSearchInput, removeItem } =
     useHistories();
+  const [sampleVideoUrl, setSampleVideoUrl] = useState<string | null>(null);
 
   return (
     <>
@@ -24,9 +26,17 @@ export default function App(): ReactElement {
             numberOfItems={items.length}
             searchInput={searchInput}
           />
-          <HistoryCards items={items} onDelete={removeItem} />
+          <HistoryCards
+            items={items}
+            onDelete={removeItem}
+            onPlaySampleVideo={setSampleVideoUrl}
+          />
         </div>
       </main>
+      <SampleVideoModal
+        url={sampleVideoUrl}
+        onClose={() => setSampleVideoUrl(null)}
+      />
     </>
   );
 }

--- a/chrome/src/react/components/HistoryCard.scss
+++ b/chrome/src/react/components/HistoryCard.scss
@@ -110,3 +110,40 @@
   font-size: 10px;
   line-height: 1;
 }
+
+.history-card__sample-video {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.history-card__play-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 46px;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--color-link);
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-link);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--color-link-hover);
+    color: var(--color-link-hover);
+  }
+}
+
+.history-card__play-count {
+  min-width: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}

--- a/chrome/src/react/components/HistoryCard.tsx
+++ b/chrome/src/react/components/HistoryCard.tsx
@@ -60,7 +60,7 @@ export default function HistoryCard({
             </button>
             {sampleVideoPlayCount !== null && (
               <span className="history-card__play-count">
-               再生回数 {sampleVideoPlayCount.toLocaleString()}回
+                再生回数 {sampleVideoPlayCount.toLocaleString()}回
               </span>
             )}
           </div>

--- a/chrome/src/react/components/HistoryCard.tsx
+++ b/chrome/src/react/components/HistoryCard.tsx
@@ -6,13 +6,17 @@ import { getPrice, getSalePercent, isSale } from '@/react/utils/historyCard';
 type HistoryCardProps = Readonly<{
   item: History;
   onDelete: (itemId: string) => void;
+  onPlaySampleVideo: (url: string) => void;
 }>;
 
 export default function HistoryCard({
   item,
-  onDelete
+  onDelete,
+  onPlaySampleVideo
 }: HistoryCardProps): ReactElement {
   const sale = isSale(item);
+  const sampleVideoUrl = item.sampleVideoUrl;
+  const sampleVideoPlayCount = item.sampleVideoPlayCount;
 
   return (
     <div className="history-card">
@@ -44,6 +48,23 @@ export default function HistoryCard({
             </span>
           )}
         </p>
+        {sampleVideoUrl && (
+          <div className="history-card__sample-video">
+            <button
+              type="button"
+              className="history-card__play-button"
+              aria-label="サンプル動画を再生"
+              onClick={() => onPlaySampleVideo(sampleVideoUrl)}
+            >
+              再生
+            </button>
+            {sampleVideoPlayCount !== null && (
+              <span className="history-card__play-count">
+               再生回数 {sampleVideoPlayCount.toLocaleString()}回
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/chrome/src/react/components/HistoryCards.tsx
+++ b/chrome/src/react/components/HistoryCards.tsx
@@ -6,17 +6,23 @@ import HistoryCard from './HistoryCard';
 type HistoryCardsProps = Readonly<{
   items: Histories;
   onDelete: (itemId: string) => void;
+  onPlaySampleVideo: (url: string) => void;
 }>;
 
 export default function HistoryCards({
   items,
-  onDelete
+  onDelete,
+  onPlaySampleVideo
 }: HistoryCardsProps): ReactElement {
   return (
     <div className="history-grid">
       {items.map((item) => (
         <div className="history-grid__item" key={item.id}>
-          <HistoryCard item={item} onDelete={onDelete} />
+          <HistoryCard
+            item={item}
+            onDelete={onDelete}
+            onPlaySampleVideo={onPlaySampleVideo}
+          />
         </div>
       ))}
     </div>

--- a/chrome/src/react/components/SampleVideoModal.scss
+++ b/chrome/src/react/components/SampleVideoModal.scss
@@ -1,0 +1,74 @@
+.sample-video-modal {
+  position: fixed;
+  z-index: 20;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.sample-video-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: rgba(0, 0, 0, 0.72);
+  cursor: pointer;
+}
+
+.sample-video-modal__content {
+  position: relative;
+  z-index: 1;
+  width: 560px;
+  height: 360px;
+  background: #000;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.sample-video-modal__player-frame {
+  width: 560px;
+  height: 360px;
+}
+
+.sample-video-modal__iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.sample-video-modal__close-button {
+  position: absolute;
+  z-index: 2;
+  top: -12px;
+  right: -12px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.95);
+  cursor: pointer;
+
+  &::before,
+  &::after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 14px;
+    height: 2px;
+    background: var(--color-text);
+    content: '';
+  }
+
+  &::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  &::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+}

--- a/chrome/src/react/components/SampleVideoModal.tsx
+++ b/chrome/src/react/components/SampleVideoModal.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+
+type SampleVideoModalProps = Readonly<{
+  url: string | null;
+  onClose: () => void;
+}>;
+
+export default function SampleVideoModal({
+  url,
+  onClose
+}: SampleVideoModalProps): ReactElement | null {
+  if (!url) return null;
+
+  return (
+    <div className="sample-video-modal" role="dialog" aria-modal="true">
+      <button
+        type="button"
+        className="sample-video-modal__backdrop"
+        aria-label="サンプル動画を閉じる"
+        onClick={onClose}
+      />
+      <div className="sample-video-modal__content">
+        <button
+          type="button"
+          className="sample-video-modal__close-button"
+          aria-label="サンプル動画を閉じる"
+          onClick={onClose}
+        />
+          <iframe
+            className="sample-video-modal__iframe"
+            title="サンプル動画"
+            src={url}
+            width="560"
+            height="360"
+            scrolling="no"
+            frameBorder="0"
+            allow="autoplay; fullscreen"
+            allowFullScreen
+          />
+
+      </div>
+    </div>
+  );
+}

--- a/chrome/src/react/components/SampleVideoModal.tsx
+++ b/chrome/src/react/components/SampleVideoModal.tsx
@@ -26,18 +26,17 @@ export default function SampleVideoModal({
           aria-label="サンプル動画を閉じる"
           onClick={onClose}
         />
-          <iframe
-            className="sample-video-modal__iframe"
-            title="サンプル動画"
-            src={url}
-            width="560"
-            height="360"
-            scrolling="no"
-            frameBorder="0"
-            allow="autoplay; fullscreen"
-            allowFullScreen
-          />
-
+        <iframe
+          className="sample-video-modal__iframe"
+          title="サンプル動画"
+          src={url}
+          width="560"
+          height="360"
+          scrolling="no"
+          frameBorder="0"
+          allow="autoplay; fullscreen"
+          allowFullScreen
+        />
       </div>
     </div>
   );

--- a/chrome/src/react/utils/historyCard.test.ts
+++ b/chrome/src/react/utils/historyCard.test.ts
@@ -13,6 +13,9 @@ const createHistory = (overrides: Partial<History> = {}): History => ({
   prices: [1000],
   salePrices: null,
   saleLimitTime: null,
+  hasSampleVideo: false,
+  sampleVideoPlayCount: null,
+  favoriteCount: null,
   ...overrides
 });
 

--- a/chrome/src/react/utils/historyCard.test.ts
+++ b/chrome/src/react/utils/historyCard.test.ts
@@ -14,6 +14,7 @@ const createHistory = (overrides: Partial<History> = {}): History => ({
   salePrices: null,
   saleLimitTime: null,
   hasSampleVideo: false,
+  sampleVideoUrl: null,
   sampleVideoPlayCount: null,
   favoriteCount: null,
   ...overrides

--- a/chrome/src/react/utils/mockHistories.ts
+++ b/chrome/src/react/utils/mockHistories.ts
@@ -12,6 +12,8 @@ export const mockHistories: Histories = [
     salePrices: [490, 990],
     saleLimitTime: new Date(2099, 11, 31, 23, 59).toString(),
     hasSampleVideo: true,
+    sampleVideoUrl:
+      'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=ofje00512/size=1280_720/',
     sampleVideoPlayCount: 58014,
     favoriteCount: 4555
   },
@@ -26,6 +28,7 @@ export const mockHistories: Histories = [
     salePrices: null,
     saleLimitTime: null,
     hasSampleVideo: false,
+    sampleVideoUrl: null,
     sampleVideoPlayCount: null,
     favoriteCount: 120
   },
@@ -40,6 +43,8 @@ export const mockHistories: Histories = [
     salePrices: null,
     saleLimitTime: null,
     hasSampleVideo: true,
+    sampleVideoUrl:
+      'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=mida00642/size=1280_720/',
     sampleVideoPlayCount: 1200,
     favoriteCount: null
   }

--- a/chrome/src/react/utils/mockHistories.ts
+++ b/chrome/src/react/utils/mockHistories.ts
@@ -13,7 +13,7 @@ export const mockHistories: Histories = [
     saleLimitTime: new Date(2099, 11, 31, 23, 59).toString(),
     hasSampleVideo: true,
     sampleVideoUrl:
-      'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=ofje00512/size=1280_720/',
+      'https://www.dmm.co.jp/service/digitalapi/-/html5_player/=/cid=ofje00512/mtype=AhRVShI_/service=digital/floor=videoa/mode=list/',
     sampleVideoPlayCount: 58014,
     favoriteCount: 4555
   },
@@ -44,7 +44,7 @@ export const mockHistories: Histories = [
     saleLimitTime: null,
     hasSampleVideo: true,
     sampleVideoUrl:
-      'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=mida00642/size=1280_720/',
+      'https://www.dmm.co.jp/service/digitalapi/-/html5_player/=/cid=mida00642/mtype=AhRVShI_/service=digital/floor=videoa/mode=list/',
     sampleVideoPlayCount: 1200,
     favoriteCount: null
   }

--- a/chrome/src/react/utils/mockHistories.ts
+++ b/chrome/src/react/utils/mockHistories.ts
@@ -10,7 +10,10 @@ export const mockHistories: Histories = [
     label: 'サンプルレーベル',
     prices: [980, 1980],
     salePrices: [490, 990],
-    saleLimitTime: new Date(2099, 11, 31, 23, 59).toString()
+    saleLimitTime: new Date(2099, 11, 31, 23, 59).toString(),
+    hasSampleVideo: true,
+    sampleVideoPlayCount: 58014,
+    favoriteCount: 4555
   },
   {
     id: 'mock002',
@@ -21,7 +24,10 @@ export const mockHistories: Histories = [
     label: 'テストレーベル',
     prices: [550],
     salePrices: null,
-    saleLimitTime: null
+    saleLimitTime: null,
+    hasSampleVideo: false,
+    sampleVideoPlayCount: null,
+    favoriteCount: 120
   },
   {
     id: 'mock003',
@@ -32,6 +38,9 @@ export const mockHistories: Histories = [
     label: 'ローカルレーベル',
     prices: [300, 1200, 2500],
     salePrices: null,
-    saleLimitTime: null
+    saleLimitTime: null,
+    hasSampleVideo: true,
+    sampleVideoPlayCount: 1200,
+    favoriteCount: null
   }
 ];

--- a/chrome/src/utils/history.test.ts
+++ b/chrome/src/utils/history.test.ts
@@ -14,7 +14,10 @@ describe('history', () => {
     label: 'レーベル',
     prices: [1000],
     salePrices: null,
-    saleLimitTime: null
+    saleLimitTime: null,
+    hasSampleVideo: false,
+    sampleVideoPlayCount: null,
+    favoriteCount: null
   });
 
   const histories = [

--- a/chrome/src/utils/history.test.ts
+++ b/chrome/src/utils/history.test.ts
@@ -16,6 +16,7 @@ describe('history', () => {
     salePrices: null,
     saleLimitTime: null,
     hasSampleVideo: false,
+    sampleVideoUrl: null,
     sampleVideoPlayCount: null,
     favoriteCount: null
   });

--- a/chrome/src/utils/itemPage.test.ts
+++ b/chrome/src/utils/itemPage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getAffiliateUrl,
+  getDeliveryItemId,
   getFavoriteCount,
   getImageUrl,
   getItemId,
@@ -118,6 +119,24 @@ describe('itemPage', () => {
 
       expect(getProductInfoValue('メーカー', root)).toBe('キチックス/妄想族');
       expect(getProductInfoValue('レーベル', root)).toBe('炉利');
+    });
+  });
+
+  describe('getDeliveryItemId', () => {
+    it('商品情報テーブルから配信品番を取得する', () => {
+      const root = {
+        querySelectorAll: () => [
+          {
+            querySelector: (selector: string) => {
+              if (selector === 'th') return { textContent: '配信品番：' };
+              if (selector === 'td') return { textContent: 'dvaj00740' };
+              return null;
+            }
+          }
+        ]
+      } as unknown as ParentNode;
+
+      expect(getDeliveryItemId(root)).toBe('dvaj00740');
     });
   });
 

--- a/chrome/src/utils/itemPage.test.ts
+++ b/chrome/src/utils/itemPage.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getAffiliateUrl,
+  getFavoriteCount,
   getImageUrl,
   getItemId,
   getProductInfoValue,
   getSaleLimitTimeText,
+  getSampleVideoPlayCount,
+  hasSampleVideo,
+  parseCountText,
   normalizeProductInfoValue,
   normalizeTitle,
   parsePriceText,
@@ -49,6 +53,14 @@ describe('itemPage', () => {
     it('価格文字列を数値に変換する', () => {
       expect(parsePriceText('1,780円')).toBe(1780);
       expect(parsePriceText('580円')).toBe(580);
+    });
+  });
+
+  describe('parseCountText', () => {
+    it('件数の文字列を数値に変換する', () => {
+      expect(parseCountText('58,014')).toBe(58014);
+      expect(parseCountText('4555')).toBe(4555);
+      expect(parseCountText('')).toBe(null);
     });
   });
 
@@ -106,6 +118,54 @@ describe('itemPage', () => {
 
       expect(getProductInfoValue('メーカー', root)).toBe('キチックス/妄想族');
       expect(getProductInfoValue('レーベル', root)).toBe('炉利');
+    });
+  });
+
+  describe('hasSampleVideo', () => {
+    it('サンプル動画プレイヤーのiframeがある場合はtrueを返す', () => {
+      const root = {
+        querySelector: (selector: string) => {
+          if (selector === 'iframe[title="サンプル動画プレイヤー"]') return {};
+          return null;
+        }
+      } as unknown as ParentNode;
+
+      expect(hasSampleVideo(root)).toBe(true);
+    });
+  });
+
+  describe('getSampleVideoPlayCount', () => {
+    it('サンプル動画の再生回数を取得する', () => {
+      const root = {
+        querySelector: (selector: string) => {
+          if (selector === '.box-sampleInfo .view-count em') {
+            return { textContent: '58,014' };
+          }
+          return null;
+        }
+      } as unknown as ParentNode;
+
+      expect(getSampleVideoPlayCount(root)).toBe(58014);
+    });
+  });
+
+  describe('getFavoriteCount', () => {
+    it('お気に入り登録数を取得する', () => {
+      const root = {
+        querySelectorAll: () => [
+          {
+            textContent: 'お気に入り登録数 4555',
+            querySelector: (selector: string) => {
+              if (selector === 'div.font-bold') {
+                return { textContent: '4555' };
+              }
+              return null;
+            }
+          }
+        ]
+      } as unknown as ParentNode;
+
+      expect(getFavoriteCount(root)).toBe(4555);
     });
   });
 });

--- a/chrome/src/utils/itemPage.test.ts
+++ b/chrome/src/utils/itemPage.test.ts
@@ -8,6 +8,7 @@ import {
   getItemId,
   getProductInfoValue,
   getSaleLimitTimeText,
+  getSampleVideoUrl,
   getSampleVideoPlayCount,
   hasSampleVideo,
   parseCountText,
@@ -46,6 +47,14 @@ describe('itemPage', () => {
     it('商品IDからアフィリエイトURLを取得する', () => {
       expect(getAffiliateUrl('sone00682')).toBe(
         'https://al.fanza.co.jp/?lurl=https%3A%2F%2Fvideo.dmm.co.jp%2Fav%2Fcontent%2F%3Fid%3Dsone00682&af_id=hira777-004'
+      );
+    });
+  });
+
+  describe('getSampleVideoUrl', () => {
+    it('商品IDからアフィリエイトID付きのサンプル動画URLを取得する', () => {
+      expect(getSampleVideoUrl('parathd04383')).toBe(
+        'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=parathd04383/size=1280_720/'
       );
     });
   });

--- a/chrome/src/utils/itemPage.test.ts
+++ b/chrome/src/utils/itemPage.test.ts
@@ -52,9 +52,9 @@ describe('itemPage', () => {
   });
 
   describe('getSampleVideoUrl', () => {
-    it('商品IDからアフィリエイトID付きのサンプル動画URLを取得する', () => {
-      expect(getSampleVideoUrl('parathd04383')).toBe(
-        'https://www.dmm.co.jp/litevideo/-/part/=/affi_id=hira777-004/cid=parathd04383/size=1280_720/'
+    it('商品IDからサンプル動画URLを取得する', () => {
+      expect(getSampleVideoUrl('ofje00512')).toBe(
+        'https://www.dmm.co.jp/service/digitalapi/-/html5_player/=/cid=ofje00512/mtype=AhRVShI_/service=digital/floor=videoa/mode=list/'
       );
     });
   });

--- a/chrome/src/utils/itemPage.ts
+++ b/chrome/src/utils/itemPage.ts
@@ -31,6 +31,17 @@ export const parsePriceText = (text: string): number => {
 };
 
 /**
+ * 件数のテキストを数値に変換する
+ */
+export const parseCountText = (text: string): number | null => {
+  const normalized = text.trim().replace(/,/g, '');
+  if (normalized === '') return null;
+
+  const count = Number(normalized);
+  return Number.isNaN(count) ? null : count;
+};
+
+/**
  * セール終了日時のテキストをDate文字列に変換する
  */
 export const parseSaleLimitTimeText = (
@@ -152,6 +163,44 @@ export const getAffiliateUrl = (itemId: string): string => {
   const itemUrl = `https://video.dmm.co.jp/av/content/?id=${itemId}`;
 
   return `https://al.fanza.co.jp/?lurl=${encodeURIComponent(itemUrl)}&af_id=${AFFILIATE_ID}`;
+};
+
+/**
+ * サンプル動画プレイヤーのiframeがあるか判定する
+ */
+export const hasSampleVideo = (root: ParentNode = document): boolean => {
+  return (
+    root.querySelector('iframe[title="サンプル動画プレイヤー"]') !== null
+  );
+};
+
+/**
+ * サンプル動画の再生回数を取得する
+ */
+export const getSampleVideoPlayCount = (
+  root: ParentNode = document
+): number | null => {
+  const countElement = root.querySelector<HTMLElement>(
+    '.box-sampleInfo .view-count em'
+  );
+
+  return parseCountText(countElement?.textContent || '');
+};
+
+/**
+ * お気に入り登録数を取得する
+ */
+export const getFavoriteCount = (root: ParentNode = document): number | null => {
+  const favoriteElement = Array.from(
+    root.querySelectorAll<HTMLElement>('div')
+  ).find((element) => {
+    return element.textContent?.includes('お気に入り登録数');
+  });
+  const countElement = favoriteElement?.querySelector<HTMLElement>(
+    'div.font-bold'
+  );
+
+  return parseCountText(countElement?.textContent || '');
 };
 
 /**

--- a/chrome/src/utils/itemPage.ts
+++ b/chrome/src/utils/itemPage.ts
@@ -166,10 +166,10 @@ export const getAffiliateUrl = (itemId: string): string => {
 };
 
 /**
- * アフィリエイトID付きのサンプル動画URLを取得する
+ * サンプル動画URLを取得する
  */
 export const getSampleVideoUrl = (itemId: string): string => {
-  return `https://www.dmm.co.jp/litevideo/-/part/=/affi_id=${AFFILIATE_ID}/cid=${itemId}/size=1280_720/`;
+  return `https://www.dmm.co.jp/service/digitalapi/-/html5_player/=/cid=${itemId}/mtype=AhRVShI_/service=digital/floor=videoa/mode=list/`;
 };
 
 /**

--- a/chrome/src/utils/itemPage.ts
+++ b/chrome/src/utils/itemPage.ts
@@ -218,6 +218,13 @@ export const getLabel = (): string => {
 };
 
 /**
+ * 配信品番を取得する
+ */
+export const getDeliveryItemId = (root: ParentNode = document): string => {
+  return getProductInfoValue('配信品番', root);
+};
+
+/**
  * 商品がセール中かどうか
  */
 const isSale = (): boolean => {

--- a/chrome/src/utils/itemPage.ts
+++ b/chrome/src/utils/itemPage.ts
@@ -176,9 +176,7 @@ export const getSampleVideoUrl = (itemId: string): string => {
  * サンプル動画プレイヤーのiframeがあるか判定する
  */
 export const hasSampleVideo = (root: ParentNode = document): boolean => {
-  return (
-    root.querySelector('iframe[title="サンプル動画プレイヤー"]') !== null
-  );
+  return root.querySelector('iframe[title="サンプル動画プレイヤー"]') !== null;
 };
 
 /**
@@ -197,15 +195,16 @@ export const getSampleVideoPlayCount = (
 /**
  * お気に入り登録数を取得する
  */
-export const getFavoriteCount = (root: ParentNode = document): number | null => {
+export const getFavoriteCount = (
+  root: ParentNode = document
+): number | null => {
   const favoriteElement = Array.from(
     root.querySelectorAll<HTMLElement>('div')
   ).find((element) => {
     return element.textContent?.includes('お気に入り登録数');
   });
-  const countElement = favoriteElement?.querySelector<HTMLElement>(
-    'div.font-bold'
-  );
+  const countElement =
+    favoriteElement?.querySelector<HTMLElement>('div.font-bold');
 
   return parseCountText(countElement?.textContent || '');
 };

--- a/chrome/src/utils/itemPage.ts
+++ b/chrome/src/utils/itemPage.ts
@@ -166,6 +166,13 @@ export const getAffiliateUrl = (itemId: string): string => {
 };
 
 /**
+ * アフィリエイトID付きのサンプル動画URLを取得する
+ */
+export const getSampleVideoUrl = (itemId: string): string => {
+  return `https://www.dmm.co.jp/litevideo/-/part/=/affi_id=${AFFILIATE_ID}/cid=${itemId}/size=1280_720/`;
+};
+
+/**
  * サンプル動画プレイヤーのiframeがあるか判定する
  */
 export const hasSampleVideo = (root: ParentNode = document): boolean => {

--- a/chrome/src/utils/itemPageWaiter.ts
+++ b/chrome/src/utils/itemPageWaiter.ts
@@ -76,10 +76,7 @@ export const waitForItemPageData = ({
   expectedItemId,
   timeoutMs = WAIT_TIMEOUT_MS
 }: WaitForItemPageDataOptions): Promise<boolean> => {
-  return waitForDomCondition(
-    () => hasItemPageData(expectedItemId),
-    timeoutMs
-  );
+  return waitForDomCondition(() => hasItemPageData(expectedItemId), timeoutMs);
 };
 
 /**

--- a/chrome/src/utils/itemPageWaiter.ts
+++ b/chrome/src/utils/itemPageWaiter.ts
@@ -1,4 +1,5 @@
 import {
+  getDeliveryItemId,
   getPriceOptionItems,
   getSaleLimitTime,
   hasProductInfoRows,
@@ -8,19 +9,20 @@ import {
 const WAIT_TIMEOUT_MS = 10000;
 
 type WaitForItemPageDataOptions = {
-  previousTitle?: string;
+  expectedItemId: string;
   timeoutMs?: number;
 };
 
 /**
  * 商品ページから必要な情報を取得できる状態か判定する
  */
-const hasItemPageData = (previousTitle: string = ''): boolean => {
+const hasItemPageData = (expectedItemId: string): boolean => {
   const title = normalizeTitle(document.title);
+  const deliveryItemId = getDeliveryItemId();
 
   return (
     title !== '' &&
-    title !== previousTitle &&
+    deliveryItemId.toLowerCase() === expectedItemId.toLowerCase() &&
     getPriceOptionItems().length > 0 &&
     hasProductInfoRows()
   );
@@ -71,10 +73,13 @@ const waitForDomCondition = (
  * 商品ページの必要な情報が読み込まれるまで待つ
  */
 export const waitForItemPageData = ({
-  previousTitle = '',
+  expectedItemId,
   timeoutMs = WAIT_TIMEOUT_MS
-}: WaitForItemPageDataOptions = {}): Promise<boolean> => {
-  return waitForDomCondition(() => hasItemPageData(previousTitle), timeoutMs);
+}: WaitForItemPageDataOptions): Promise<boolean> => {
+  return waitForDomCondition(
+    () => hasItemPageData(expectedItemId),
+    timeoutMs
+  );
 };
 
 /**

--- a/chrome/webpack.config.js
+++ b/chrome/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env, argv) => {
     entry: {
       historyWatcher: './src/chrome/historyWatcher.ts',
       historySaver: './src/chrome/historySaver.ts',
+      sampleVideoReader: './src/chrome/sampleVideoReader.ts',
       histories: './src/react/histories.tsx',
       popup: './src/chrome/popup.ts'
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dmm-history",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "packageManager": "pnpm@10.21.0",
   "engines": {
     "node": "24.7.0"


### PR DESCRIPTION
## 概要

商品ページからサンプル動画情報とお気に入り登録数を取得し、履歴画面からサンプル動画を再生できるようにしました。

## 変更内容

- 履歴に以下の情報を保存
  - サンプル動画の有無
  - サンプル動画URL
  - サンプル動画の再生回数
  - お気に入り登録数
- iframe内からサンプル動画の再生回数を取得
- 商品ページの描画完了を配信品番で判定
- 履歴カードに再生ボタンと再生回数を追加
- サンプル動画を再生するモーダルを追加
- READMEのダウンロードリンクを最新リリースへ変更
- バージョンを `1.3.0` に更新

## 確認項目

- [x] `pnpm format:check`
- [x] `pnpm check-types`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] サンプル動画情報が履歴に保存される
- [x] 履歴カードからサンプル動画を再生できる
- [x] サンプル動画がない商品でも履歴を保存できる